### PR TITLE
Fix faulty key types

### DIFF
--- a/environments/appdev/types/RNASeqSampleSet.yaml
+++ b/environments/appdev/types/RNASeqSampleSet.yaml
@@ -6,8 +6,8 @@ versions:
   - path: sampleset_desc
     full-text: true
   - path: num_samples
-    key-type: integer
+    keyword-type: integer
   - path: num_replicates
-    key-type: integer
+    keyword-type: integer
   - path: source
-    key-type: keyword
+    keyword-type: keyword

--- a/environments/appdev/types/SingleEndLibrary.yaml
+++ b/environments/appdev/types/SingleEndLibrary.yaml
@@ -13,7 +13,7 @@ versions:
   - path: phred_type
     keyword-type: keyword
   - path: read_count
-    keywork-type: integer
+    keyword-type: integer
     ui-name: Number of reads
   - path: read_length_mean
     keyword-type: integer

--- a/environments/ci/types/RNASeqSampleSet.yaml
+++ b/environments/ci/types/RNASeqSampleSet.yaml
@@ -6,8 +6,8 @@ versions:
   - path: sampleset_desc
     full-text: true
   - path: num_samples
-    key-type: integer
+    keyword-type: integer
   - path: num_replicates
-    key-type: integer
+    keyword-type: integer
   - path: source
-    key-type: keyword
+    keyword-type: keyword

--- a/environments/ci/types/SingleEndLibrary.yaml
+++ b/environments/ci/types/SingleEndLibrary.yaml
@@ -13,7 +13,7 @@ versions:
   - path: phred_type
     keyword-type: keyword
   - path: read_count
-    keywork-type: integer
+    keyword-type: integer
     ui-name: Number of reads
   - path: read_length_mean
     keyword-type: integer

--- a/environments/next/types/RNASeqSampleSet.yaml
+++ b/environments/next/types/RNASeqSampleSet.yaml
@@ -6,8 +6,8 @@ versions:
   - path: sampleset_desc
     full-text: true
   - path: num_samples
-    key-type: integer
+    keyword-type: integer
   - path: num_replicates
-    key-type: integer
+    keyword-type: integer
   - path: source
-    key-type: keyword
+    keyword-type: keyword

--- a/environments/next/types/SingleEndLibrary.yaml
+++ b/environments/next/types/SingleEndLibrary.yaml
@@ -13,7 +13,7 @@ versions:
   - path: phred_type
     keyword-type: keyword
   - path: read_count
-    keywork-type: integer
+    keyword-type: integer
     ui-name: Number of reads
   - path: read_length_mean
     keyword-type: integer

--- a/environments/prod/types/RNASeqSampleSet.yaml
+++ b/environments/prod/types/RNASeqSampleSet.yaml
@@ -6,8 +6,8 @@ versions:
   - path: sampleset_desc
     full-text: true
   - path: num_samples
-    key-type: integer
+    keyword-type: integer
   - path: num_replicates
-    key-type: integer
+    keyword-type: integer
   - path: source
-    key-type: keyword
+    keyword-type: keyword

--- a/environments/prod/types/SingleEndLibrary.yaml
+++ b/environments/prod/types/SingleEndLibrary.yaml
@@ -13,7 +13,7 @@ versions:
   - path: phred_type
     keyword-type: keyword
   - path: read_count
-    keywork-type: integer
+    keyword-type: integer
     ui-name: Number of reads
   - path: read_length_mean
     keyword-type: integer


### PR DESCRIPTION
Some keys were misspelled leading to the default keyword-type of "keyword" being used. The good news is that the new validation flags this as an error. the bad news is that from what I recall, we will need to reindex the types because they are changing from "keyword" to "integer"